### PR TITLE
Add homepage gallery section

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,4 +23,26 @@
         <a href="impressum.html">Impressum</a> | 
         <a href="kontakt.html">Kontakt</a>
     </footer>
+    <section class="gallery">
+        <div class="frame">
+            <img src="lecture1.jpg" alt="Lecture 1">
+            <div class="symbol" style="color: #5B8266;">&#9733;</div>
+            <div class="title" style="color: #294936;">Business Process Improvement</div>
+        </div>
+        <div class="frame">
+            <img src="lecture2.jpg" alt="Lecture 2">
+            <div class="symbol" style="color: #5B8266;">&#9733;</div>
+            <div class="title" style="color: #294936;">IT-Recht</div>
+        </div>
+        <div class="frame">
+            <img src="lecture3.jpg" alt="Lecture 3">
+            <div class="symbol" style="color: #5B8266;">&#9733;</div>
+            <div class="title" style="color: #294936;">IT-Architekturen</div>
+        </div>
+        <div class="frame">
+            <img src="lecture4.jpg" alt="Lecture 4">
+            <div class="symbol" style="color: #5B8266;">&#9733;</div>
+            <div class="title" style="color: #294936;">Web Development</div>
+        </div>
+    </section>
 </body>

--- a/style/style.css
+++ b/style/style.css
@@ -71,13 +71,43 @@ button {
 button:hover {
     background-color: #2980b9;
 }
-/* P1e6b */
+
 header nav a {
     color: #5B8266;
     margin: 0 1em;
 }
 
-/* P1f7a */
 footer a {
     color: #294936;
+}
+
+/* Gallery styles */
+.gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1em;
+    padding: 1em;
+}
+
+.frame {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    padding: 1em;
+    text-align: center;
+}
+
+.frame img {
+    max-width: 100%;
+    height: auto;
+}
+
+.symbol {
+    font-size: 2em;
+    color: #5B8266;
+}
+
+.title {
+    font-size: 1.2em;
+    color: #294936;
+    margin-top: 0.5em;
 }


### PR DESCRIPTION
Fixes #6

Add a gallery section to the homepage with four frames, each containing an image, a symbol in Viridian, and a title in Brunswick Green.

* **index.html**
  - Add a gallery section with four frames after the existing content.
  - Each frame contains an image, a symbol in Viridian, and a title in Brunswick Green.
  - Rename the titles of the frames as follows: Lecture 1 -> Business Process Improvement, Lecture 2 -> IT-Recht, Lecture 3 -> IT-Architekturen, Lecture 4 -> Web Development.

* **style/style.css**
  - Add styles for the gallery section, including layout and frame styles.
  - Use CSS Grid for the gallery layout.
  - Ensure frames are responsive and resize appropriately for different screen sizes.
  - Set the symbol color to Viridian (#5B8266) and the title color to Brunswick Green (#294936).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Poolnudel/WebDev/issues/6?shareId=5fc4fc04-6e11-426e-b95f-5b27fd5f0bf9).